### PR TITLE
SFT-44 Update README to use AWS link for Astyle

### DIFF
--- a/Development-Guide/Style-Guide/README.adoc
+++ b/Development-Guide/Style-Guide/README.adoc
@@ -19,8 +19,8 @@ Follow AStyle, bindings are available in sublime and vim.
 To install the latest version in debian based operating systems:
 
 ```bash
-wget 'https://sourceforge.net/projects/astyle/files/astyle/astyle%202.06/astyle_2.06_linux.tar.gz/download'
-tar -zxvf download
+wget 'https://s3-us-west-2.amazonaws.com/ucsolarteam.hostedfiles/astyle'
+tar -zxvf astyle
 cd astyle/build/gcc
 make release
 sudo make install


### PR DESCRIPTION
To ensure everyone can download the correct version, we will encourage
the use of the same link that travis uses to install astyle.